### PR TITLE
Default GitLab Credentials Configuration for OAuth2 Token Usage

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -27,6 +27,10 @@ GITLAB_TOKEN = os.getenv('GITLAB_TOKEN', 'gitlab token')
 GITLAB_ADMIN_USER = os.getenv('GITLAB_ADMIN_USER', 'admin username')
 GITLAB_ADMIN_PASS = os.getenv('GITLAB_ADMIN_PASS', 'admin password')
 
+if GITLAB_URL == 'https://gitlab.com/' and GITLAB_ADMIN_USER == '' and GITLAB_ADMIN_PASS == '':
+    # see https://forum.gitlab.com/t/how-to-git-clone-via-https-with-personal-access-token-in-private-project/43418/4
+    GITLAB_ADMIN_USER = 'oauth2'
+    GITLAB_ADMIN_PASS = GITLAB_TOKEN
 GITEA_URL = os.getenv('GITEA_URL','https://gitea.dest.com')
 GITEA_TOKEN = os.getenv('GITEA_TOKEN', 'gitea token')
 


### PR DESCRIPTION
This pull request introduces a conditional configuration update that automatically sets the `GITLAB_ADMIN_USER` to 'oauth2' and uses the `GITLAB_TOKEN` as the `GITLAB_ADMIN_PASS` when specific conditions are met. This adjustment is targeted at improving the Git clone process for private projects on GitLab.com using a personal access token, without explicitly providing a username and password.

Changes:
- Implemented a condition to check if the `GITLAB_URL` is set to 'https://gitlab.com/' and both [GITLAB_ADMIN_USER](url) and `GITLAB_ADMIN_PASS` are empty.
- Under these conditions, the system now sets `GITLAB_ADMIN_USER` to 'oauth2' and assigns [GITLAB_ADMIN_PASS](url) the value of [GITLAB_TOKEN](url).