### PR TITLE
add keep_base_url=True to support different response domain

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -60,7 +60,7 @@ def main():
     print()
 
     # private token or personal token authentication
-    gl = gitlab.Gitlab(GITLAB_URL, private_token=GITLAB_TOKEN)
+    gl = gitlab.Gitlab(GITLAB_URL, private_token=GITLAB_TOKEN, keep_base_url=True)
     gl.auth()
     assert(isinstance(gl.user, gitlab.v4.objects.CurrentUser))
     print_info("Connected to Gitlab, version: " + str(gl.version()))


### PR DESCRIPTION
When gitlab responses a different base domain it is used by the gitlab lib. 
In my case this was somehow wrong and setting keep_base_url=True fixed it.
With that always the env var is used.
This should fix #15 
Thanks for the great project by the way.