### PR TITLE
Fixing incorect project name and add tested version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This script support migrating the following data:
  - Groups
  - Public SSH keys
 
-Tested with Gitlab Version 13.0.6 and Gitea Version 1.11.6.
+Tested with Gitlab Version 17.1.1 and Gitea Version 1.22.1
 
 ## Usage
 Change items in the config section of the script.


### PR DESCRIPTION
Hello,

I successfully migrated from Gitlab 1.17.1 to Gitea 1.22.1, So I'm adding this to README.md.

Also, I propose to replace `project.name` with `project.path` in the code. The main reason for this is that in Gitlab you can create a project with a name containing spaces and specify a different name for repo url/path.
This is not possible in Gitea as project name and path must be the same.
So, I propose to use `project.path` instead of  `project.name` as Gitea repo name in order to keep the same url for Gitea repo. 

Thanks,

A.